### PR TITLE
Add user manual

### DIFF
--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,5 @@
+# pixi environments
+.pixi
+*.pdf
+user_manual_files
+*.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Render the docs
+
+To render the docs locally, install the dependencies as follows:
+
+1. [Install pixi](https://pixi.sh/latest/installation/)
+2. To render the docs as HTML, ``cd`` into the docs folder run:
+
+  ```bash
+  pixi run render_html
+  ```
+
+3. To render the docs as PDF, run:
+
+  ```bash
+  pixi run install_tinytex
+  pixi run render_pdf
+  ```

--- a/docs/pixi.lock
+++ b/docs/pixi.lock
@@ -1,0 +1,117 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dart-sass-1.59.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/deno-1.46.3-h8d7d278_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/deno-dom-0.1.41-h1a6af48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.25.8-h11686cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.6.3-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.32-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/typst-0.13.0-ha073cba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_30.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_30.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/win-64/dart-sass-1.59.1-h57928b3_0.conda
+  sha256: d8599cab2a09b725bf9fb9de72513cd6253162f07679213874361db5284c4e8a
+  md5: 7b884d6ae77792e5fdb47cc5c43f0676
+  license: MIT
+  license_family: MIT
+  size: 2866045
+  timestamp: 1747420839766
+- conda: https://conda.anaconda.org/conda-forge/win-64/deno-1.46.3-h8d7d278_0.conda
+  sha256: a87dd9d3a143ca6566279643520b91f1b381369484558b575f26b3c5cdef491d
+  md5: b8a93975407a73d2735d4a715497e76a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 39736817
+  timestamp: 1726026282966
+- conda: https://conda.anaconda.org/conda-forge/win-64/deno-dom-0.1.41-h1a6af48_0.conda
+  sha256: 199ed9fea4d58cea10572cc5a7fb3ad0fbefd189cb785667639dbfc4210ed2ab
+  md5: 84bc9003c48bf69d4663b00f692404cb
+  depends:
+  - deno >=1.24.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: MIT
+  license_family: MIT
+  size: 294346
+  timestamp: 1736703764252
+- conda: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.25.8-h11686cb_0.conda
+  sha256: ba13b690716821c77d73a359c8856292426b88a3e2a0d8fc1a4c3fb9c8d5001d
+  md5: 57b2dceb293b8a2b9fb8e9a92d6a1f70
+  license: MIT
+  license_family: MIT
+  size: 4239973
+  timestamp: 1752965756067
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.6.3-h57928b3_0.conda
+  sha256: ffdb8fd1da7419f6625c8b2339a12f9669a705ada4177b763cc796c60763f734
+  md5: 9b999036cccf0d5a94ed3c0b0edbb905
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 25331299
+  timestamp: 1739198094952
+- conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.32-h57928b3_0.conda
+  sha256: b053cba6f4e0c275951246d8629f6a319ca5f4bba78dedd06656a4bb3de42da7
+  md5: 2bd53524cdf3cc88ae93fbbd2cc0eb60
+  depends:
+  - dart-sass
+  - deno >=1.46.3,<1.46.4.0a0
+  - deno-dom >=0.1.41,<0.1.42.0a0
+  - esbuild
+  - pandoc 3.6.3
+  - typst 0.13.0
+  license: MIT
+  license_family: MIT
+  size: 16403530
+  timestamp: 1750116299399
+- conda: https://conda.anaconda.org/conda-forge/win-64/typst-0.13.0-ha073cba_0.conda
+  sha256: 25f27ecedc6704c25fd585e0c526d21ac33d0806d3493dcf669213b1e8ca1f53
+  md5: c081083e160c80c00521871c9446495e
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 13133057
+  timestamp: 1739977188460
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_30.conda
+  sha256: 8e16a8c3270d88735234a8097d45efea02b49751800c83b6fd5f2167a3828f52
+  md5: 76b6febe6dea7991df4c86f826f396c5
+  depends:
+  - vc14_runtime >=14.42.34433
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17962
+  timestamp: 1753139853244
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_30.conda
+  sha256: 2958ef637509d69ea496b091dc579f1bf38687575b65744e73d157cfe56c9eca
+  md5: fa6802b52e903c42f882ecd67731e10a
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_30
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 754911
+  timestamp: 1753139843755

--- a/docs/pixi.toml
+++ b/docs/pixi.toml
@@ -1,0 +1,14 @@
+[workspace]
+authors = ["JoerivanEngelen <joerivanengelen@hotmail.com>"]
+channels = ["conda-forge"]
+name = "fdf-docs"
+platforms = ["win-64"]
+version = "0.1.0"
+
+[tasks]
+install_tinytex = "quarto install tinytex"
+render_pdf = "quarto render user_manual.qmd --to pdf --output user_manual.pdf"
+render_html = "quarto render user_manual.qmd --to html --output user_manual.html"
+
+[dependencies]
+quarto = ">=1.7.32,<2"

--- a/docs/user_manual.qmd
+++ b/docs/user_manual.qmd
@@ -1,0 +1,108 @@
+---
+title: "Fair Data Finder"
+author: "FAIR data team"
+crossref:
+  chapters: true
+---
+
+# Introduction
+
+This document describes how to use the Deltares Fair Data Finder. The Fair Data
+Finder consists of 5 screens, some of which are only limited to a specific set
+of users:
+
+1. [Search](#search) (Everyone)
+2. [Register](#register) (Deltares employees)
+3. [Domains](#domains) (Data stewards)
+4. [Keywords](#keywords) (Data stewards)
+5. [Groups](#groups) (Admins)
+
+This document will walk you through each of these screens. 
+
+# Logging in
+
+You will be able to see much more functionality when you log in. Clicking
+"Login" will forward you to the login screen. Here, you'll be able to login
+using your Deltares credentials.
+
+TIP: If you are a Deltares employee and use the Edge browser, you'll be
+  automatically logged in when clicking "Login".
+
+# Search
+
+The *Search* screen is open to everyone, including those who are not logged in.
+However, these users will not be able to see most datasets, unless a dataset is
+registered as viewable to be completely public. 
+
+## Item view
+The left-hand side contains a search bar, below which are all registered items
+(=registered datasets in a project) found in the search. The search bar is
+self-explanatory: Type in your search query and the FDF will search all project
+titles, descriptions etc. and present them under the search bar. You can further
+restrict the search by clicking the *Add Filter* button above the search bar and
+selecting a filter. Once you've found an item you like, you can click *View
+details* to view the registered item's full details (project number, full description, coordinate reference system).
+
+## Map
+The right-hand side contains a map which can be used to see all datasets in a
+certain area. Click the *Search this area* button to search all dataset in a
+certain area.
+
+# Register
+
+The register screen is only accessible to Deltares employees. The screen will
+show you a table with all registered datasets. The most important button here is
+the *Register new dataset* button, which takes you to the registration screen.
+This will first force you to select a Domain to which your dataset broadly
+belongs to (e.g. Ecology). After you have selected a Domain, the rest of the
+registration form will open. 
+
+**Full description registration here, probably better to write when this form stabilizes**
+
+# Domains
+
+This screen is only accessible to Data Stewards. Domains are the expertise
+domains to which each dataset can be assigned. This screen shows a table with
+all registered domains, and which keywords are assigned to each domain. More
+domains can be added by clicking the *Add domain* button. This will open a new
+screen to add a new domain. Here, you can fill in a description and keyword
+domain, created in [Keywords](#keywords), that belongs to the domain.
+
+::: {.callout-note} 
+Why Domains? We were looking for some topical way to categorize dataset. We
+think this works better than using management layers, as these are changed quite
+frequently. For example, in the last years a management layer has been removed
+(RIP units), departments have been renamed, and even split up and redistributed
+over other departments. This would entail frequent changes to the categories,
+which means frequent updates to existing registered items in the database. The
+topical domains have been created together with the Data Stewards, thus should
+pretty much cover the organization. We expect these topical domains to be more
+stable, although more domains can turn out to be necessary when Deltares
+broadens its scope and threads new topical territorities. Contact the Data
+Stewards if you think a new domain is necessary.
+:::
+
+# Keywords
+
+In the Keywords screen, keywords can be configured. This screen can only be
+accessed by Data Stewards. Keywords are specified in a 3-tier
+hierarchy: domains contain keyword groups. Keyword groups contain keywords.
+A keyword domain can be assigned to [a domain in the domain screen.](#domains)
+
+To add new keywords:
+
+1. In the Keyword management screen, under "Section", click *Domains*
+2. Then in the *Add domain* bar enter your domain name (e.g. "Groundwater"),
+   click *Add domain* to add it to the list
+3. Then under "Section" click on *Keyword Groups*
+4. Here, fill in a Dutch group name in Group name NL (e.g. "Grondwater
+   software"), an English name in Group name EN, and select a "facility type"
+   (e.g. Numerical modelling).
+5. Click on the keyword group you just created under "Keyword Groups"
+6. On the right-hand side, you can add individual keywords here. Make sure to
+   add an english and dutch name here.
+
+# Groups
+
+Here, user groups can be defined with their respective authorizations. This
+screen is only accessible to admins. 


### PR DESCRIPTION
Add a first version of the user manual for the UI. This can be sent to the Data Stewards. I think adding these to the source repo reduces the risk that changes in the UI cause a discrepency between actual UI and user manual. I now added them as quarto docs; with this it's easy to render as HTML as well as PDF. The latter is probably unimportant once we release, but helps the reviewing process for reviewers unfamiliar with code reviews in Github, as they can add comments on a PDF which they send to one of us. The README explains how to install and render the docs.

 I purposely didn't do the following:

- Add a detailed description of the registration form, as there probably will be changes made to this soon based on user feedback, as well as tooltips will be added which will do the same (but better, because directly available in the UI)
- Add screenshots. These become outdated quickly as the UI changes.

Let me know what you think.